### PR TITLE
Vue should be a development dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "url": "https://github.com/krilor/vue-suggest/issues"
   },
   "homepage": "https://github.com/krilor/vue-suggest#readme",
-  "dependencies": {
-    "vue": "^2.5.13"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
@@ -38,6 +36,7 @@
     "eslint": "^4.15.0",
     "eslint-plugin-vue": "^4.1.0",
     "uglify-js": "^3.3.4",
+    "vue": "^2.5.13"
     "vue-loader": "^13.6.2",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.10.1",


### PR DESCRIPTION
Users of lib will include their own Vue version. If you would like to constrain the version of Vue, use [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).