### PR TITLE
HTML attributes 'required' and 'autofocus' for input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ The search element emits three events.
 | list-classes | String | Used to customize appearance. Adds classnames to the unordered options list. | `suggest-list` |
 | item-classes | String | Used to customize appearance. Adds classnames to the option list items. | `suggest-item` |
 | placeholder | String | Used to customize appearance. Adds placeholder text in search box. | `Search..` |
-| required | Boolean | Used to customize required attribute of the input element. | false |
-| autofocus | Boolean | Used to customize autofocus attribute of the input element. | false |
+| required | Boolean | Used to customize the required attribute of the input element. | false |
+| autofocus | Boolean | Used to customize the autofocus attribute of the input element. | false |
 
 ### Customizing the template for each option in the list.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The search element emits three events.
 | list-classes | String | Used to customize appearance. Adds classnames to the unordered options list. | `suggest-list` |
 | item-classes | String | Used to customize appearance. Adds classnames to the option list items. | `suggest-item` |
 | placeholder | String | Used to customize appearance. Adds placeholder text in search box. | `Search..` |
+| required | Boolean | Used to customize required attribute of the input element. | false |
+| autofocus | Boolean | Used to customize autofocus attribute of the input element. | false |
 
 ### Customizing the template for each option in the list.
 

--- a/src/Suggest.vue
+++ b/src/Suggest.vue
@@ -6,6 +6,8 @@
       v-on:input="updateValue($event.target.value)"
       :class="inputClasses"
       :placeholder="placeholder"
+      :required="required"
+      :autofocus="autofocus"
       @keyup.esc="isOpen = false"
       @keydown.down="moveDown"
       @keydown.up="moveUp"
@@ -63,6 +65,16 @@
         type: String,
         required: false,
         default: 'Search..'
+      },
+      required: {
+        type: Boolean,
+        required: false,
+        default: false
+      },
+      autofocus: {
+        type: Boolean,
+        required: false,
+        default: false
       }
     },
     data () {


### PR DESCRIPTION
Provide to possibility to set the HTML attributes 'required' and 'autofocus' on the input field using Vue properties.