### PR TITLE
Modify open state based on current input value

### DIFF
--- a/src/Suggest.vue
+++ b/src/Suggest.vue
@@ -122,7 +122,7 @@
       * $emits the current value types in input event
       */
       updateValue: function(value) {
-        this.isOpen = !!this.value
+        this.isOpen = !!value
         this.highlightedPosition = NaN
         this.$emit('input', value)
       }


### PR DESCRIPTION
In the old version the open state was updated based on the previous input value and not the current value from the input event.

Example:
1. Current value of this.value is an empty string ("")
2. User types a letter into the input field ("x")
3. The open state (isOpen) will still represent a not open state, because the the old value of the variable this.value ("") is used to perform the check and not the value variable ("x")
4. Afterwards the new value is emitted and it could be updated on the this.value variable if it was bound back to the value variable from the event (v-model)

If the user types a second letter, then the value "x" is used to set the open state (isOpen) and so the the options will be shown.